### PR TITLE
Add the option to include shell scripts in data.json

### DIFF
--- a/src/pages/app.js
+++ b/src/pages/app.js
@@ -58,7 +58,7 @@ class App extends Component {
   }
 
   fetchData() {
-    const url = 'http://localhost:3000/data.json'
+    const url = 'https://raw.githubusercontent.com/max-itup/content/master/mac/data.json'
     fetch(url)
       .then(response => response.json())
       .then(data => {

--- a/src/pages/app.js
+++ b/src/pages/app.js
@@ -58,7 +58,7 @@ class App extends Component {
   }
 
   fetchData() {
-    const url = 'https://raw.githubusercontent.com/max-itup/content/master/mac/data.json'
+    const url = 'http://localhost:3000/data.json'
     fetch(url)
       .then(response => response.json())
       .then(data => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -29,6 +29,7 @@ export function objectFromArray(arr, key = 'id') {
     let brew_items = [];
     let gem_items = [];
     let os_settings_items = [];
+    let shell_script_items = [];
 
     itemsArray.forEach(item => {
       if (item.type === 'cask') {
@@ -39,6 +40,8 @@ export function objectFromArray(arr, key = 'id') {
         gem_items.push(item);
       } else if (item.category === 'os_settings') {
         os_settings_items.push(item);
+      } else if (item.category === 'shell_scripts') {
+        shell_script_items.push(item);
       }
     });
 
@@ -47,6 +50,7 @@ export function objectFromArray(arr, key = 'id') {
     script = script.replace('{{PACKAGES}}', statics.brew(brew_items));
     script = script.replace('{{GEMS}}', statics.gems(gem_items));
     script = script.replace('{{OS_SETTINGS}}', statics.os_settings(os_settings_items));
+    script = script.replace('{{SHELL_SCRIPTS}}', statics.shell_scripts(shell_script_items));
     return script;
   }
 

--- a/src/utils/statics.js
+++ b/src/utils/statics.js
@@ -26,6 +26,7 @@ brew update
 {{PACKAGES}}{{CASKS}}{{GEMS}}
 echo "🧼 Cleaning up..."
 brew cleanup -s
+{{SHELL_SCRIPTS}}
 {{OS_SETTINGS}}
 echo "🎉 Setup complete!"`;
 
@@ -71,6 +72,18 @@ GEMS=(
 )
 echo "💎 Installing Ruby gems..."
 sudo gem install \${GEMS[@]} -N
+`
+}
+
+export function shell_scripts(items) {
+    if (items.length === 0) {
+        return  "" ;
+    }
+
+    const codes = items.map(c => c.code).join(" && \\\n");
+    return `
+echo "💻 Running Scripts..."
+${codes}
 `
 }
 


### PR DESCRIPTION
Hey!

Tested with data that looks something like this:
```json
    {
      "id": "shell_scripts",
      "name": "Shell Scripts",
      "order": 1
    }

    {
      "id": "ls",
      "type": "shell_scripts",
      "name": "List directories",
      "description": "A simple command",
      "category": "shell_scripts",
      "code": "ls -la"
    },
    {
      "id": "defaults",
      "type": "shell_scripts",
      "name": "Configure defaults",
      "description": "A setting to allow full screen iOS Simulators",
      "category": "shell_scripts",
      "code": "defaults write com.apple.iphonesimulator AllowFullscreenMode -bool YES"
    },
```

With longer commands the cards can look ugly, also I don't know if there is a clear icon for this feature available or not :)

Anyway I thought I'd push the changes early so you can give feedback on the direction. Cheers!